### PR TITLE
fix: fix shared memory issue

### DIFF
--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require('power-assert');
+const server = require('../lib/server');
+const server_copy = require('./supports/server');
+
+describe('test/server.test', () => {
+  it('should create different type of server in one process', function* () {
+    const instance = yield server.create('xxx', 10000);
+    const instance_2 = yield server_copy.create('yyy', 10000);
+
+    assert(instance && instance === instance_2);
+
+    instance.close();
+  });
+});

--- a/test/supports/server.js
+++ b/test/supports/server.js
@@ -2,8 +2,8 @@
 
 const net = require('net');
 const Base = require('sdk-base');
-const Packet = require('./protocol/packet');
-const Response = require('./protocol/response');
+const Packet = require('../../lib/protocol/packet');
+const Response = require('../../lib/protocol/response');
 
 // share memory in current process
 let serverMap;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

如果 node_modules 下面有多个 cluster-client 版本，可能会导致问题。现在将 serverMap 和 typeSet 两个缓存对象挂载到 global 上，在一个进程内部共享