### PR TITLE
fix: follower _registerChannel retry forever, when socket closed passively

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -86,6 +86,7 @@ class ClusterClient extends Base {
         server = yield ClusterServer.create(name, port);
       }
 
+      this[innerClient] && this[innerClient].close();
       if (server) {
         this[innerClient] = new Leader(Object.assign({ server }, this.options));
         debug('[ClusterClient:%s] has seized port %d, and serves as leader client.', name, port);


### PR DESCRIPTION
修复，当`Follower`跟`Leader`的连接非主动断开（调用close）时，如果恰好执行到`Follower` 的`_registerChannel`方法时，会导致`_registerChannel`方法的中`this.send`报错后3秒重试，并一直进行下去。因为连接断开后client会调用`[init]`方法，该方法会new 一个新的`Follower`,原先旧的`Follower`如果在正在进行`_registerChannel` `setTimeout`重试,就会一直进行下去，因为`_registerChannel`中的`this.send`一直会失败。对应的错误栈信息：
```
2017-10-12 14:10:13,311 WARN 8618 [ClusterClient:ZookeeperAPIClient@192.168.1.123:2181,192.168.1.119:2181,192.168.1.120:2181,192.168.1.121:2181,192.168.1.122:2181] follower closed, and try to init it again
^[[32m[2017-10-12 14:10:13.344] [INFO] mercurylock - ^[[39m[2,8618] - connected success!!
2017-10-12 14:10:16,312 WARN 8618 nodejs.Error: register to channel: ZookeeperAPIClient@192.168.1.123:2181,192.168.1.119:2181,192.168.1.120:2181,192.168.1.121:2181,192.168.1.122:2181 failed, will retry after 3s, [TCPBase] The socket was closed. (address: 127.0.0.1:21789)
    at Follower.send (/data/server/lock-sxlock/node_modules/tcp-base/lib/base.js:182:19)
    at Follower.send (/data/server/lock-sxlock/node_modules/cluster-client/lib/follower.js:106:18)
    at Follower._registerChannel (/data/server/lock-sxlock/node_modules/cluster-client/lib/follower.js:216:10)
    at Timeout.setTimeout (/data/server/lock-sxlock/node_modules/cluster-client/lib/follower.js:225:31)
    at Timeout._onTimeout (/data/server/lock-sxlock/node_modules/async-listener/glue.js:188:31)
    at tryOnTimeout (timers.js:232:11)
    at Timer.listOnTimeout (timers.js:202:5)
```