### PR TITLE
[v1.7.x backport] feat: response with whole error object instead of only stack, message

### DIFF
--- a/lib/follower.js
+++ b/lib/follower.js
@@ -32,7 +32,6 @@ class Follower extends Base {
     // avoid warning message
     this.setMaxListeners(100);
   }
-
   get isLeader() {
     return false;
   }
@@ -69,21 +68,19 @@ class Follower extends Base {
     const packet = Packet.decode(buf);
     const connObj = packet.connObj;
     if (connObj && connObj.type === 'invoke_result') {
+      let data;
+      if (packet.data) {
+        data = this.options.transcode.decode(packet.data);
+      }
       if (connObj.success) {
-        let data;
-        if (packet.data) {
-          data = this.options.transcode.decode(packet.data);
-        }
         return {
           id: packet.id,
           isResponse: packet.isResponse,
           data,
         };
       }
-      const error = new Error(connObj.message);
-      if (connObj.stack) {
-        error.stack = connObj.stack;
-      }
+      const error = new Error(data.message);
+      Object.assign(error, data);
       return {
         id: packet.id,
         isResponse: packet.isResponse,
@@ -195,7 +192,6 @@ class Follower extends Base {
       data,
       timeout: this.options.responseTimeout,
     });
-
     // send invoke request
     this.send({
       id: req.id,
@@ -230,9 +226,9 @@ class Follower extends Base {
         debug('[Follower:%s] register to channel: %s success', this.options.name, this.options.name);
         this.ready(true);
       } else {
-        const err = new Error(res.message);
-        err.stack = res.stack;
-        this.ready(err);
+        const error = new Error(res.error.message);
+        Object.assign(error, res.error);
+        this.ready(error);
       }
     });
   }

--- a/lib/leader.js
+++ b/lib/leader.js
@@ -328,6 +328,11 @@ class Leader extends Base {
             }
 
             if (err) {
+              const data = Object.assign({
+                stack: err.stack,
+                name: err.name,
+                message: err.message,
+              }, err);
               err.method = connObj.method;
               err.args = connObj.args;
               this._errorHandler(err);
@@ -335,9 +340,8 @@ class Leader extends Base {
               res.connObj = {
                 type: 'invoke_result',
                 success: false,
-                message: err.message,
-                stack: err.stack,
               };
+              res.data = this._transcode.encode(data);
             } else {
               debug('[Leader:%s] send method:%s result to follower, result: %j', this.options.name, connObj.method, result);
               const data = this._transcode.encode(result);
@@ -362,10 +366,14 @@ class Leader extends Base {
         this.ready(err => {
           if (err) {
             res.connObj = { type: 'register_channel_res' };
-            res.data = this._transcode.encode({
-              success: false,
+            const data = Object.assign({
               message: err.message,
               stack: err.stack,
+              name: err.name,
+            }, err);
+            res.data = this._transcode.encode({
+              success: false,
+              error: data,
             });
           } else {
             res.connObj = { type: 'register_channel_res' };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -560,6 +560,7 @@ describe('test/index.test.js', () => {
       done = pedding(done, 3);
       let trigger_1 = false;
       let trigger_2 = false;
+      let trigger_3 = false;
       client_1.subscribe({
         dataId: 'com.alibaba.dubbo.demo.DemoService',
       }, val => {
@@ -610,6 +611,9 @@ describe('test/index.test.js', () => {
         client_3.subscribe({
           dataId: 'com.alibaba.dubbo.demo.DemoService',
         }, val => {
+          if (trigger_3) return;
+
+          trigger_3 = true;
           assert(val && val.length > 0);
           console.log('3', val.map(url => url.host));
           if (val.length === 2) {

--- a/test/supports/cluster_server.js
+++ b/test/supports/cluster_server.js
@@ -3,8 +3,10 @@
 const cluster = require('cluster');
 const http = require('http');
 const net = require('net');
-const numCPUs = require('os').cpus().length;
+let numCPUs = require('os').cpus().length;
 const APIClientBase = require('../..').APIClientBase;
+
+if (numCPUs <= 1) numCPUs = 2;
 
 function startServer(port) {
   class TestClient extends APIClientBase {
@@ -49,6 +51,7 @@ function startServer(port) {
 
   if (cluster.isMaster) {
     console.log(`Master ${process.pid} is running`);
+    const workerSet = new Set();
 
     // Fork workers.
     for (let i = 0; i < numCPUs; i++) {
@@ -58,13 +61,23 @@ function startServer(port) {
     cluster.on('exit', (worker, code, signal) => {
       console.log(`worker ${worker.process.pid} died, code: ${code}, signal: ${signal}`);
     });
-    setTimeout(() => {
-      process.exit(0);
-    }, 2000);
+    cluster.on('message', worker => {
+      workerSet.add(worker.id);
+      if (workerSet.size === numCPUs) {
+        process.exit(0);
+      }
+    });
+    // setTimeout(() => {
+    //   process.exit(0);
+    // }, 10000);
   } else {
     const client = new TestClient();
-    client.ready(() => {
-      console.log(`Worker ${process.pid} client ready, leader: ${client.isClusterClientLeader}`);
+    client.ready(err => {
+      if (err) {
+        console.log(`Worker ${process.pid} client ready failed, leader: ${client.isClusterClientLeader}, errMsg: ${err.message}`);
+      } else {
+        console.log(`Worker ${process.pid} client ready, leader: ${client.isClusterClientLeader}`);
+      }
     });
     let latestVal;
     client.subscribe({ key: 'foo' }, val => {
@@ -75,6 +88,10 @@ function startServer(port) {
     setInterval(() => {
       client.publish({ key: 'foo', value: 'bar ' + Date() });
     }, 200);
+
+    setTimeout(() => {
+      process.send(cluster.worker.id);
+    }, 5000);
 
     // Workers can share any TCP connection
     // In this case it is an HTTP server
@@ -94,4 +111,7 @@ server.listen(0, () => {
   setTimeout(() => {
     startServer(address.port);
   }, 100);
+  setTimeout(() => {
+    server.close();
+  }, 10000);
 });


### PR DESCRIPTION
* feat: response with whole error object instead of only stack, message

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->