### PR TITLE
fix: subscribe is not working on single thread mode

### DIFF
--- a/lib/wrapper/single.js
+++ b/lib/wrapper/single.js
@@ -72,6 +72,7 @@ class InnerClient extends SdkBase {
 
     if (!this._subSet.has(key)) {
       this._subSet.add(key);
+      this.on(key, listener);
       this._realClient[this._subscribeMethodName](reg, result => {
         const data = transcode.encode(result);
         this._subData.set(key, data);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
Cluster-Client's single thread mode

##### Description of change
<!-- Provide a description of the change below this comment. -->

When using Cluster-Client in our repo, we found client.subscribe is not working in single thread mode. By adding this line to the source code, it's working in our case.