### PR TITLE
fix: MaxListenersExceededWarning

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,6 @@
 const debug = require('util').debuglog('cluster-client:lib:server');
 const net = require('net');
 const Base = require('sdk-base');
-
-const { setMaxListeners } = require('events');
-
 const { sleep } = require('./utils');
 const Packet = require('./protocol/packet');
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,9 @@
 const debug = require('util').debuglog('cluster-client:lib:server');
 const net = require('net');
 const Base = require('sdk-base');
+
+const { setMaxListeners } = require('events');
+
 const { sleep } = require('./utils');
 const Packet = require('./protocol/packet');
 
@@ -186,6 +189,10 @@ class ClusterServer extends Base {
     try {
       const server = await claimServer(port);
       instance = new ClusterServer({ server, port });
+
+      // defaultMaxListeners is 10，
+      instance.setMaxListeners(20);
+
       typeSet.add(key);
       serverMap.set(port, instance);
       return instance;


### PR DESCRIPTION
increase to avoid nodejs warning `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [ClusterServer]. Use emitter.setMaxListeners() to increase limit`