### PR TITLE
feat: set ClusterServer default maximum listeners up to 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,3 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
-    with:
-      checkTest: false

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,6 @@
 const debug = require('util').debuglog('cluster-client:lib:server');
 const net = require('net');
 const Base = require('sdk-base');
-
-const { setMaxListeners } = require('events');
-
 const { sleep } = require('./utils');
 const Packet = require('./protocol/packet');
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -69,8 +69,9 @@ class ClusterServer extends Base {
    *
    * @class
    * @param {Object} options
-   *  - {net.Server} server - the server
-   *  - {Number} port - the port
+   * @param {net.Server} options.server - the server
+   * @param {Number} options.port - the port
+   * @param {Number} [options.maxListeners] maximum of listeners, default is 20
    */
   constructor(options) {
     super();
@@ -88,6 +89,7 @@ class ClusterServer extends Base {
     this._server.once('error', err => {
       this.emit('error', err);
     });
+    this.setMaxListeners(options.maxListeners || 20);
   }
 
   get isClosed() {
@@ -187,10 +189,7 @@ class ClusterServer extends Base {
     // compete for the local port, if got => leader, otherwise follower
     try {
       const server = await claimServer(port);
-      instance = new ClusterServer({ server, port });
-
-      instance.setMaxListeners(options?.maxListeners || 20);
-
+      instance = new ClusterServer({ server, port, ...options });
       typeSet.add(key);
       serverMap.set(port, instance);
       return instance;

--- a/lib/server.js
+++ b/lib/server.js
@@ -164,9 +164,11 @@ class ClusterServer extends Base {
    *
    * @param {String} name - the client name
    * @param {Number} port - the port
+   * @param {Object} [options] - create instance options
+   * @param {Number} [options.maxListeners] maximum of listeners, default is 20
    * @return {ClusterServer} server
    */
-  static async create(name, port) {
+  static async create(name, port, options) {
     const key = `${name}@${port}`;
     if (typeof port !== 'number') {
       throw new Error(`[ClusterClient.server.create:${name}] port should be a number, but got ${JSON.stringify(port)}`);
@@ -187,8 +189,7 @@ class ClusterServer extends Base {
       const server = await claimServer(port);
       instance = new ClusterServer({ server, port });
 
-      // defaultMaxListeners is 10，
-      instance.setMaxListeners(20);
+      instance.setMaxListeners(options?.maxListeners || 20);
 
       typeSet.add(key);
       serverMap.set(port, instance);

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,9 @@
 const debug = require('util').debuglog('cluster-client:lib:server');
 const net = require('net');
 const Base = require('sdk-base');
+
+const { setMaxListeners } = require('events');
+
 const { sleep } = require('./utils');
 const Packet = require('./protocol/packet');
 
@@ -186,6 +189,10 @@ class ClusterServer extends Base {
     try {
       const server = await claimServer(port);
       instance = new ClusterServer({ server, port });
+
+      // defaultMaxListeners is 10，
+      instance.setMaxListeners(20);
+
       typeSet.add(key);
       serverMap.set(port, instance);
       return instance;

--- a/lib/wrapper/cluster.js
+++ b/lib/wrapper/cluster.js
@@ -33,7 +33,7 @@ class ClusterClient extends Base {
     const port = this.options.port;
     let server;
     if (this.options.isLeader === true) {
-      server = await ClusterServer.create(name, port);
+      server = await ClusterServer.create(name, port, { maxListeners: this.options.maxListeners });
       if (!server) {
         throw new Error(`create "${name}" leader failed, the port:${port} is occupied by other`);
       }
@@ -42,7 +42,7 @@ class ClusterClient extends Base {
       await ClusterServer.waitFor(port, this.options.maxWaitTime);
     } else {
       debug('[ClusterClient:%s] init cluster client, try to seize the leader on port:%d', name, port);
-      server = await ClusterServer.create(name, port);
+      server = await ClusterServer.create(name, port, { maxListeners: this.options.maxListeners });
     }
 
     if (server) {


### PR DESCRIPTION
closes https://github.com/node-modules/cluster-client/pull/65

increase to avoid nodejs warning

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [ClusterServer]. Use emitter.setMaxListeners() to increase limit
```